### PR TITLE
Validate the entire URI

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func denyUsernsHost(w http.ResponseWriter, r *http.Request) {
 				logData[k] = v
 			}
 		}
-		if v, ok := v["UsernsMode"]; ok && v.(string) == "host" && strings.HasSuffix(req.RequestURI, "/containers/create") {
+		if v, ok := v["UsernsMode"]; ok && v.(string) == "host" && strings.Contains(req.RequestURI, "/containers/create") {
 			// Apparently you don't send 403 for a successful deny.
 			code = http.StatusOK
 			resp.Msg = "userns=host is not allowed"


### PR DESCRIPTION
Check the entire URI for the container create method, not just the suffix.

It is possible to by pass the plugin by appending a "?" to the end of the url if using the API.

With the "?" the url is still valid (http parameters) and will be processed successfully by the docker api and the plugin will be bypassed.